### PR TITLE
fix [profile.py]: updated list so that current_user is the user=request.auth.user)

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,7 +81,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             current_user.recommends = Recommendation.objects.filter(recommender=current_user)
 
             serializer = ProfileSerializer(


### PR DESCRIPTION
Description of PR that completes issue here...
When an authenticated client submits a GET request to the /profile resource, the user profile is returned depending of the authentication token provided.

## Changes
- current_user = Customer.objects.get(user=request.auth.user)

**Response**
HTTP/1.1 200 OK

## Testing
- open postman
- open 'Profile' directory
- click 'User profile'
- run GET request for user
- under the Headers tab, replace the Authorization Token to a different user and run 'GET' again 
(you should get a different user back depending on the Token provided)

## Related Issues
-Fixes #22 