### PR TITLE
Nah delete product test

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -154,6 +154,8 @@ class Products(ViewSet):
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
             return Response(serializer.data)
+        except Product.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -2,6 +2,7 @@ import json
 import datetime
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models import Product
 
 
 class ProductTests(APITestCase):
@@ -95,7 +96,29 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
-    # TODO: Delete product
+    def test_delete_product(self):
+        """
+            Ensure we can delete an existing product.
+                {
+                    "id": 1,
+                    "name": "Optima",
+                    "price": 1655.15,
+                    "number_sold": 0,
+                    "description": "2008 Kia",
+                    "quantity": 3,
+                    "created_date": "2019-05-21",
+                    "location": "Onguday",
+                    "image_path": null,
+                    "average_rating": 1.0
+                }
+        """
+        self.test_create_product()
+        url = "/products/1"
+
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_ratings(self):
         #creating new product to test

--- a/tests/product.py
+++ b/tests/product.py
@@ -112,7 +112,9 @@ class ProductTests(APITestCase):
                     "average_rating": 1.0
                 }
         """
+        #Create a product, so we can test deleting said product
         self.test_create_product()
+        #entire product is represented here
         url = "/products/1"
 
         response = self.client.delete(url)


### PR DESCRIPTION
Created a new test in the tests/product.py module that verifies that a product can be deleted and not shown to users.

## Changes
modified:   tests/product.py  // added  test_delete_product
modified:  bangazonapi/views/product.py  // added except: to try/catch block for 404 not found

## Testing
checkout to nah-deleteProductTest
in terminal run: python3 manage.py test tests -v 1

you will see: FAIL: test_create_payment_type (I have not gotten to that issue ticket yet)

but delete test will PASS.


## Related Issues
- Fixes #8 