### PR TITLE
Nah delete payment type

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()
@@ -56,6 +56,8 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+        except Payment.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -154,6 +154,8 @@ class Products(ViewSet):
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
             return Response(serializer.data)
+        except Product.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -40,4 +40,25 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+    def test_delete_payment(self):
+        """
+            Ensure we can delete an existing payment.
+                {
+                    "id": 1,
+                    "url": "http://localhost:8000/paymenttypes/1",
+                    "merchant_name": "Visa",
+                    "account_number": "24ijio68948fj8439",
+                    "expiration_date": "2020-01-01",
+                    "create_date": "2019-11-11"
+                }
+        """
+        #Create a product, so we can test deleting said product
+        self.test_create_payment_type()
+        #entire product is represented here
+        url = "/paymenttypes/1"
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -3,7 +3,6 @@ import json
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-
 class PaymentTests(APITestCase):
     def setUp(self) -> None:
         """
@@ -16,7 +15,6 @@ class PaymentTests(APITestCase):
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
 
     def test_create_payment_type(self):
         """
@@ -56,8 +54,6 @@ class PaymentTests(APITestCase):
         self.test_create_payment_type()
         #entire product is represented here
         url = "/paymenttypes/1"
-
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(url)

--- a/tests/product.py
+++ b/tests/product.py
@@ -2,6 +2,7 @@ import json
 import datetime
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models import Product
 
 
 class ProductTests(APITestCase):
@@ -95,7 +96,29 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
-    # TODO: Delete product
+    def test_delete_product(self):
+        """
+            Ensure we can delete an existing product.
+                {
+                    "id": 1,
+                    "name": "Optima",
+                    "price": 1655.15,
+                    "number_sold": 0,
+                    "description": "2008 Kia",
+                    "quantity": 3,
+                    "created_date": "2019-05-21",
+                    "location": "Onguday",
+                    "image_path": null,
+                    "average_rating": 1.0
+                }
+        """
+        self.test_create_product()
+        url = "/products/1"
+
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_ratings(self):
         #creating new product to test

--- a/tests/product.py
+++ b/tests/product.py
@@ -112,7 +112,9 @@ class ProductTests(APITestCase):
                     "average_rating": 1.0
                 }
         """
+        #Create a product, so we can test deleting said product
         self.test_create_product()
+        #entire product is represented here
         url = "/products/1"
 
         response = self.client.delete(url)


### PR DESCRIPTION
You can now test deleting payments.

## Changes
modified:   bangazonapi/views/paymenttype.py
modified:   tests/payments.py

## Testing
checkout to nah-deleteProductTest
in terminal run: python3 manage.py test tests -v 1

## Related Issues
- Fixes #9  // main issue I was addressing.
- Fixes #19   // this error came up in my terminal when trying to run the delete_test, so I was able to include it with this PR.